### PR TITLE
fix: download svg for icon

### DIFF
--- a/install
+++ b/install
@@ -165,7 +165,7 @@ if [ -d "$USER_APPLICATIONS_DIR" ]; then
 
   wget -q --show-progress --progress=bar:force \
     -O "${icon_path:-$bin_path/dayz-ctl.svg}" \
-    raw_url/$DAYZ_CTL_VERSION/extra/dayz-ctl.svg ||
+    $raw_url/$DAYZ_CTL_VERSION/extra/dayz-ctl.svg ||
     fail "Can't download dayz-ctl from https://github.com/WoozyMasta/dayz-ctl"
 
   printf '%s\n' \


### PR DESCRIPTION
Не загружалась svg картинка для иконки, потерял переменную.

Лог выполнения скрипта с ошибкой:
```bash
+ wget -q --show-progress --progress=bar:force -O /home/random/.local/share/icons/dayz-ctl.svg raw_url/master/extra/dayz-ctl.svg
+ fail 'Can'\''t download dayz-ctl from https://github.com/WoozyMasta/dayz-ctl'
+ printf '\e[1;31mERROR:\e[0m %s\n' 'Can'\''t download dayz-ctl from https://github.com/WoozyMasta/dayz-ctl'
ERROR: Can't download dayz-ctl from https://github.com/WoozyMasta/dayz-ctl
```