### PR TITLE
fix previews for zsh

### DIFF
--- a/dayz-ctl
+++ b/dayz-ctl
@@ -516,7 +516,7 @@ fzfServers() {
     .[] | '"$filter"' [.key, .value.name] | @tsv
   ' "$DAYZ_SERVER_DB" | \
   fzf --delimiter '\t' --with-nth 2 \
-    --preview 'fzfPreview {1}' --preview-window=$preview | \
+    --preview 'bash -c "fzfPreview {1}"' --preview-window=$preview | \
   cut -f1
 }
 
@@ -815,12 +815,12 @@ getFavoriteServers() {
     done
     printf '%s\n' "${history[@]}" | sort -nr | \
     fzf --delimiter '\t' --with-nth 4 \
-      --preview 'fzfPreview {3}' --preview-window=right | \
+      --preview 'bash -c "fzfPreview {3}"' --preview-window=right | \
     cut -f3-4
   else
     printf '%s\n' "${online[@]}" "${offline[@]}" | \
     fzf --delimiter '\t' --with-nth 3 \
-      --preview 'fzfPreview {2}' --preview-window=right | \
+      --preview 'bash -c "fzfPreview {2}"' --preview-window=right | \
     cut -f2-3
   fi
 }


### PR DESCRIPTION
fixes #11 

This ensures it works when run from zsh

[Screencast from 2023-03-24 19-36-27.webm](https://user-images.githubusercontent.com/61225/227474641-136084d6-58ff-4b80-baa0-60e312113653.webm)

Without: 

[Screencast from 2023-03-24 19-38-36.webm](https://user-images.githubusercontent.com/61225/227475058-cf4eaf87-17bc-4aca-9c90-1a3992a24aba.webm)


Still works in bash too.

[Screencast from 2023-03-24 19-41-51.webm](https://user-images.githubusercontent.com/61225/227476102-cc7e2039-e43c-46a9-8a10-9da3dfba4aac.webm)


btw you should split this up and use bats to create tests.
